### PR TITLE
Update CMake min version to a wide range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 
 find_package(Java 1.8)
 


### PR DESCRIPTION
CI jobs [start breaking](https://github.com/staticlibs/duckdb-java/actions/runs/14161411171/job/39667793256) with the following message:

> Compatibility with CMake < 3.5 has been removed from CMake.

This change updates the minimum required CMake version to a range from `3.5` to `3.29` the same way as it is used in the [main DuckDB repo](https://github.com/duckdb/duckdb/blob/255c7840929ed146f4ce672d624f80535370c323/CMakeLists.txt#L1).

edit: replaced version `3.16` with a range